### PR TITLE
BUGFIX: RethinkDB Backend

### DIFF
--- a/kaneda/backends/rethink.py
+++ b/kaneda/backends/rethink.py
@@ -39,7 +39,6 @@ class RethinkBackend(BaseBackend):
                 self.connection = r.connect(host=host, port=port, db=db, timeout=timeout)
         self.db = db
         self.table_name = table_name
-        self.connection = r.connect(db=db, timeout=timeout)
         self._create_database()
 
     def _get_payload(self, name, value, tags, id_):

--- a/kaneda/backends/rethink.py
+++ b/kaneda/backends/rethink.py
@@ -39,6 +39,8 @@ class RethinkBackend(BaseBackend):
                 self.connection = r.connect(host=host, port=port, db=db, timeout=timeout)
         self.db = db
         self.table_name = table_name
+        if self.connection is None:
+            self.connection = r.connect(db=db, timeout=timeout)
         self._create_database()
 
     def _get_payload(self, name, value, tags, id_):


### PR DESCRIPTION
Currently, a new connection without the username, password, host and port will be created for the backend even if one was already successfully created.