### PR TITLE
Fix subpackage name in example code

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -14,7 +14,7 @@ or define your custom backend subclassing the :code:`BaseBackend` class.
 
 The following example it shows how to send metrics with Elasticsearch as a backend::
 
-    from kaneda.backend import ElasticsearchBackend
+    from kaneda.backends import ElasticsearchBackend
     from kaneda import Metrics
 
     backend = ElasticsearchBackend(index_name='myindex', app_name='myapp', host='localhost',


### PR DESCRIPTION
A subpackage name was missing an 's'.  On the Usage page in the docs, the Elasticsearch sample code was

`from kaneda.backend import ElasticsearchBackend`

which throws a ModuleNotFoundError.

It should be:

`from kaneda.backends import ElasticsearchBackend`